### PR TITLE
fix: http-server must ignore the query part

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,9 +44,8 @@ function deploy(config, ready) {
             response.end();
             return;
         }
-
-        let requestedFile = path.resolve(path.normalize(path.join(cwd, ...request.url.split(path.posix.sep))));
-
+        const url = new URL(request.url, `http://${request.headers.host}`);
+        let requestedFile = path.resolve(path.normalize(path.join(cwd, ...url.pathname.split(path.posix.sep))));
         if (requestedFile !== root) {
             if (!requestedFile.startsWith(cwd)) {
                 response.writeHead(404, 'Not found');


### PR DESCRIPTION
## Description

## Problem
When requesting a path that has a query parameter, such as `/index.html?hello=world` the server returns a 404.

## Solution
Ignore the query part.


### Checklist
- [x] The title starts either with `feat:`, `fix:`, or `chore:`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes

