### PR TITLE
added two parameters: only-get-or-head and check-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ steps:
       no-cache: false
       index-files: |
         ["index.html", "index.htm"]
-	  allowed-methods: |
+      allowed-methods: |
         ["GET", "HEAD"]
       content-types: |
         {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # http-server-action
 ---
-An action that spawns an http server to serve files. By @Eun
-Improved to handle index.html in root of directories.
+An action that spawns an http server to serve files. 
+This project is forked from https://github.com/Eun/http-server-action
+
+Changes: Improved to handle index.html in root of directories.
 
 ## Inputs
 ### `directory`
@@ -49,7 +51,7 @@ steps:
       directory: ${{ github.workspace }}
       port: 8080
       no-cache: false
-	  check-index: false
+      check-index: false
       content-types: |
         {
           "appcache": "text/cache-manifest",

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Port that should be used (default is `8080`) (*optional*)
 ### `no-cache`
 No-Cache determiantes wheter the server sets the Cache-Control header or not (default is `false`) (*optional*)
 
-### `check-index`
-If true, look for index.html instead of false, show directory listing (default is `false`) (*optional*)
+### `index-files`
+If set and directory is requested, look for those files, instead of show directory listing (default is EMPTY, sample is `[index.html, index.htm]`) (*optional*)
 
-### `only-get-or-head`
-Throw HTTP-Error 405 on other methods than GET or HEAD (default is `true`) (*optional*)
+### `allowed-methods`
+Throw HTTP-Error 405 on other methods than the methods given (default is `[GET, HEAD]`) (*optional*)
 
 ### `content-types`
 A JSON object of content-types that should be served (*optional*)
@@ -54,7 +54,8 @@ steps:
       directory: ${{ github.workspace }}
       port: 8080
       no-cache: false
-      check-index: false
+      index-files: [index.html, index.htm]
+	  allowed-methods: [GET, HEAD]
       content-types: |
         {
           "appcache": "text/cache-manifest",

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ No-Cache determiantes wheter the server sets the Cache-Control header or not (de
 ### `check-index`
 If true, look for index.html instead of false, show directory listing (default is `false`) (*optional*)
 
+### `only-get-or-head`
+Throw HTTP-Error 405 on other methods than GET or HEAD (default is `true`) (*optional*)
+
 ### `content-types`
 A JSON object of content-types that should be served (*optional*)
 Default:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # http-server-action
 ---
-An action that spawns an http server to serve files.
+An action that spawns an http server to serve files. By @Eun
+Improved to handle index.html in root of directories.
 
 ## Inputs
 ### `directory`
@@ -11,6 +12,9 @@ Port that should be used (default is `8080`) (*optional*)
 
 ### `no-cache`
 No-Cache determiantes wheter the server sets the Cache-Control header or not (default is `false`) (*optional*)
+
+### `check-index`
+If true, look for index.html instead of false, show directory listing (default is `false`) (*optional*)
 
 ### `content-types`
 A JSON object of content-types that should be served (*optional*)
@@ -45,6 +49,7 @@ steps:
       directory: ${{ github.workspace }}
       port: 8080
       no-cache: false
+	  check-index: false
       content-types: |
         {
           "appcache": "text/cache-manifest",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # http-server-action
 ---
 An action that spawns an http server to serve files. 
-This project is forked from https://github.com/Eun/http-server-action
-
-Changes: Improved to handle index.html in root of directories.
 
 ## Inputs
 ### `directory`

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Port that should be used (default is `8080`) (*optional*)
 No-Cache determiantes wheter the server sets the Cache-Control header or not (default is `false`) (*optional*)
 
 ### `index-files`
-If set and directory is requested, look for those files, instead of show directory listing (default is EMPTY, sample is `[index.html, index.htm]`) (*optional*)
+If set and directory is requested, look for those files, instead of show directory listing (default is EMPTY, sample is `["index.html", "index.htm"]`) (*optional*)
 
 ### `allowed-methods`
-Throw HTTP-Error 405 on other methods than the methods given (default is `[GET, HEAD]`) (*optional*)
+Throw HTTP-Error 405 on other methods than the methods given (default is `["GET", "HEAD"]`) (*optional*)
 
 ### `content-types`
 A JSON object of content-types that should be served (*optional*)
@@ -54,8 +54,10 @@ steps:
       directory: ${{ github.workspace }}
       port: 8080
       no-cache: false
-      index-files: [index.html, index.htm]
-	  allowed-methods: [GET, HEAD]
+      index-files: |
+        ["index.html", "index.htm"]
+	  allowed-methods: |
+        ["GET", "HEAD"]
       content-types: |
         {
           "appcache": "text/cache-manifest",

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # https://help.github.com/en/articles/metadata-syntax-for-github-actions
-name: 'HTTP Server Action (tts-mod)'
+name: 'HTTP Server Action'
 description: 'GitHub Action to start a http server that serves files'
 author: 'Tobias Salzmann'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Whether to look for index.html or show directory listing'
     required: false
     default: false
+  only-get-or-head:
+    description: 'Whether to throw 405 on other methods than GET or HEAD'
+    required: false
+    default: true
   content-types:
     description: 'Content Types to serve'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # https://help.github.com/en/articles/metadata-syntax-for-github-actions
-name: 'HTTP Server Action'
+name: 'HTTP Server Action (tts-mod)'
 description: 'GitHub Action to start a http server that serves files'
 author: 'Tobias Salzmann'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -18,14 +18,16 @@ inputs:
     description: 'Whether to set the Cache-Control header or not'
     required: false
     default: false
-  check-index:
-    description: 'Whether to look for index.html or show directory listing'
+  index-files:
+    description: 'If set and directory is requested, look for those files, instead of show directory listing'
     required: false
-    default: false
-  only-get-or-head:
-    description: 'Whether to throw 405 on other methods than GET or HEAD'
+    default: |
+      []
+  allowed-methods:
+    description: 'Throw HTTP-Error 405 on other methods than the methods given'
     required: false
-    default: true
+    default: |
+      ["GET", "HEAD"]
   content-types:
     description: 'Content Types to serve'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Whether to set the Cache-Control header or not'
     required: false
     default: false
+  check-index:
+    description: 'Whether to look for index.html or show directory listing'
+    required: false
+    default: false
   content-types:
     description: 'Content Types to serve'
     required: false

--- a/main.js
+++ b/main.js
@@ -59,11 +59,11 @@ if (config.noCache === null || config.noCache.length == 0) {
     config.noCache = config.noCache === 'true';
 }
 
-config.IndexFiles = core.getInput('index-files');
-if (config.IndexFiles === null || config.IndexFiles.length == 0) {
-    config.IndexFiles = [];
+config.indexFiles = core.getInput('index-files');
+if (config.indexFiles === null || config.indexFiles.length == 0) {
+    config.indexFiles = [];
 } else {
-    config.IndexFiles = JSON.parse(config.IndexFiles);
+    config.indexFiles = JSON.parse(config.indexFiles);
 }
 
 config.contentTypes = core.getInput('content-types');

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ let config = {
     root: null,
     port: null,
     noCache: null,
+	checkIndex: null,
     contentTypes: null,
 };
 
@@ -59,6 +60,13 @@ if (config.noCache === null || config.noCache.length == 0) {
     config.noCache = false;
 } else {
     config.noCache = config.noCache === 'true';
+}
+
+config.checkIndex = core.getInput('check-index');
+if (config.checkIndex === null || config.checkIndex.length == 0) {
+    config.checkIndex = false;
+} else {
+    config.checkIndex = config.checkIndex === 'true';
 }
 
 config.contentTypes = core.getInput('content-types');

--- a/main.js
+++ b/main.js
@@ -2,7 +2,6 @@ const process = require('process');
 const core = require('@actions/core');
 const server = require('./server.js');
 
-
 if (process.argv.length === 3 && process.argv[2] === 'serve') {
     process.on('SIGTERM', () => {
         process.exit(0);
@@ -35,7 +34,6 @@ let config = {
 	allowedMethods: null,
     contentTypes: null
 };
-
 
 config.root = core.getInput('directory');
 if (config.root === null || config.root.length == 0) {

--- a/main.js
+++ b/main.js
@@ -27,15 +27,13 @@ if (process.argv.length === 3 && process.argv[2] === 'serve') {
     return;
 }
 
-
-
 let config = {
     root: null,
     port: null,
     noCache: null,
-	checkIndex: null,
-	onlyGetOrHead: null,
-    contentTypes: null,
+	IndexFiles: null,
+	allowedMethods: null,
+    contentTypes: null
 };
 
 
@@ -63,18 +61,11 @@ if (config.noCache === null || config.noCache.length == 0) {
     config.noCache = config.noCache === 'true';
 }
 
-config.checkIndex = core.getInput('check-index');
-if (config.checkIndex === null || config.checkIndex.length == 0) {
-    config.checkIndex = false;
+config.IndexFiles = core.getInput('index-files');
+if (config.IndexFiles === null || config.IndexFiles.length == 0) {
+    config.IndexFiles = [];
 } else {
-    config.checkIndex = config.checkIndex === 'true';
-}
-
-config.onlyGetOrHead = core.getInput('only-get-or-head');
-if (config.onlyGetOrHead === null || config.onlyGetOrHead.length == 0) {
-    config.onlyGetOrHead = true;
-} else {
-    config.onlyGetOrHead = config.onlyGetOrHead === 'true';
+    config.IndexFiles = JSON.parse(config.IndexFiles);
 }
 
 config.contentTypes = core.getInput('content-types');
@@ -97,7 +88,12 @@ if (config.contentTypes === null || config.contentTypes.length == 0) {
     config.contentTypes = JSON.parse(config.contentTypes);
 }
 
-
+config.allowedMethods = core.getInput('allowed-methods');
+if (config.allowedMethods === null || config.allowedMethods.length == 0) {
+    config.allowedMethods = ['GET', 'HEAD'];
+} else {
+    config.allowedMethods = JSON.parse(config.allowedMethods);
+}
 
 const cp = require('child_process');
 const child = cp.fork(__filename, ['serve'], { detached: true, silent: true });

--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@ let config = {
     port: null,
     noCache: null,
 	checkIndex: null,
+	onlyGetOrHead: null,
     contentTypes: null,
 };
 
@@ -67,6 +68,13 @@ if (config.checkIndex === null || config.checkIndex.length == 0) {
     config.checkIndex = false;
 } else {
     config.checkIndex = config.checkIndex === 'true';
+}
+
+config.onlyGetOrHead = core.getInput('only-get-or-head');
+if (config.onlyGetOrHead === null || config.onlyGetOrHead.length == 0) {
+    config.onlyGetOrHead = true;
+} else {
+    config.onlyGetOrHead = config.onlyGetOrHead === 'true';
 }
 
 config.contentTypes = core.getInput('content-types');

--- a/main.js
+++ b/main.js
@@ -30,8 +30,8 @@ let config = {
     root: null,
     port: null,
     noCache: null,
-	IndexFiles: null,
-	allowedMethods: null,
+    indexFiles: null,
+    allowedMethods: null,
     contentTypes: null
 };
 

--- a/server.js
+++ b/server.js
@@ -31,7 +31,6 @@ function deploy(config, ready) {
         cwd += path.sep;
     }
 
-
     function toPosixPath(url) {
         return path.posix.join(...url.split(path.sep));
     }
@@ -137,6 +136,5 @@ function deploy(config, ready) {
         ready(server);
     });
 }
-
 
 exports.deploy = deploy;

--- a/server.js
+++ b/server.js
@@ -19,6 +19,9 @@ function deploy(config, ready) {
     if (config.checkIndex === undefined || config.checkIndex === null) {
         config.checkIndex = false;
     }
+    if (config.onlyGetOrHead === undefined || config.onlyGetOrHead === null) {
+        config.onlyGetOrHead = true;
+    }
     if (config.contentTypes === undefined || config.contentTypes === null || config.contentTypes.length == 0) {
         config.contentTypes = {};
     }
@@ -42,7 +45,7 @@ function deploy(config, ready) {
             );
         }
 
-        if (request.method !== 'GET' && request.method !== 'HEAD') {
+        if (config.onlyGetOrHead && (request.method !== 'GET' && request.method !== 'HEAD')) {
             response.writeHead(405, 'Method Not Allowed');
             response.end();
             return;

--- a/server.js
+++ b/server.js
@@ -15,8 +15,8 @@ function deploy(config, ready) {
     if (config.noCache === undefined || config.noCache === null) {
         config.noCache = false;
     }
-    if (config.IndexFiles === undefined || config.IndexFiles === null) {
-        config.IndexFiles = [];
+    if (config.indexFiles === undefined || config.indexFiles === null) {
+        config.indexFiles = [];
     }
     if (config.allowedMethods === undefined || config.allowedMethods === null) {
         config.allowedMethods = ['GET', 'HEAD'];

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ function deploy(config, ready) {
     if (config.noCache === undefined || config.noCache === null) {
         config.noCache = false;
     }
-	if (config.checkIndex === undefined || config.checkIndex === null) {
+    if (config.checkIndex === undefined || config.checkIndex === null) {
         config.checkIndex = false;
     }
     if (config.contentTypes === undefined || config.contentTypes === null || config.contentTypes.length == 0) {
@@ -63,13 +63,20 @@ function deploy(config, ready) {
             }
         }
 
-        const stat = fs.statSync(requestedFile);
+        let stat = fs.statSync(requestedFile);
 
         if (stat.isDirectory()) {
 			let indexFound = false;
 			if (config.checkIndex) {
-				if(fs.existsSync(requestedFile + '/index.html')){
-					requestedFile = requestedFile + '/index.html';
+				let indexFile = '';
+				if (requestedFile.endsWith(path.sep)) {
+					indexFile = requestedFile + 'index.html';
+				} else {
+					indexFile = requestedFile + path.sep + 'index.html';
+				}
+				if(fs.existsSync(indexFile)){
+					requestedFile = indexFile;
+					stat = fs.statSync(requestedFile);
 					indexFound = true;
 				}
 			}


### PR DESCRIPTION
## Description
I am using your project to mock an API for testing purposes.
I needed two more functions to make it work.

## Problem
I need to test API requests to something like /users/1 AND /users/1/profile .
So what I did was creating a folder structure and placed in the "/users/1"-folder an index.html
But it returns a directory listing even if a index.html is present.

And I need POST requests, but the original code blocks them.

## Solution
Introduced parameter check-index for looking for index.html, before return directory listing.
Introduced parameter only-get-or-head to allow to set it to false, to ignore method check.

## Notes
If you merge this, nothing significant will happen for existing users, because the default parameters say not to use the functions introduced in this request.
