### PR TITLE
chore: Update to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # https://help.github.com/en/articles/metadata-syntax-for-github-actions
-name: 'HTTP Server Action (16-mod)'
+name: 'HTTP Server Action'
 description: 'GitHub Action to start a http server that serves files'
 author: 'Tobias Salzmann'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # https://help.github.com/en/articles/metadata-syntax-for-github-actions
-name: 'HTTP Server Action'
+name: 'HTTP Server Action (16-mod)'
 description: 'GitHub Action to start a http server that serves files'
 author: 'Tobias Salzmann'
 branding:
@@ -47,6 +47,6 @@ inputs:
         "xml": "text/xml"
       }
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'
   post: 'post.js'


### PR DESCRIPTION
## Description
Update from Node12 to Node16

## Problem
There is a deprecation note for Node 12 on every run.

## Solution
Changed the string node12 to node16

## Notes
Everything seems to work as expected.

### Checklist
- [x] The title starts either with `feat:`, `fix:`, or `chore:`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes

