### PR TITLE
fix: update recommended version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ steps:
     uses: actions/checkout@v2
   -
     name: Serve Files
-    uses: Eun/http-server-action@v1
+    uses: Eun/http-server-action@v1.0.6
     with:
       directory: ${{ github.workspace }}
       port: 8080


### PR DESCRIPTION
README says to use `@v1`, but that's an old version and doesn't include some functionality described in the README (e.g. `index-files`, [added in v1.0.4 afaict](https://github.com/Eun/http-server-action/commit/46b4de0f6ad193415bb8b986a55ba9953d4fc23c#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6)). `index-files` was just failing silently for me, until I noticed this.

I think most official actions have e.g. `v1` as a branch, not a tag, which can be kept up to date with the latest changes. Not sure whether `@v1` is salvage-able, since it's already a tag, but could keep in mind for `@v2`…

Also technically possible to forcibly update the `v1` tag to the latest 1.x.x release tag…