### PR TITLE
fix: tag major version during release

### DIFF
--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -1,0 +1,28 @@
+# this workflow runs when a release was published.
+on:
+  release:
+    types: [published]
+
+name: "release_published"
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
+        name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      -
+        name: Tag
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag $(echo ${{env.GITHUB_REF_SLUG}} | cut -d. -f1)
+      -
+        name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -19,10 +19,12 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git tag -d $(echo ${{env.GITHUB_REF_SLUG}} | cut -d. -f1)
           git tag $(echo ${{env.GITHUB_REF_SLUG}} | cut -d. -f1)
       -
         name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          force: true
+          tags: true


### PR DESCRIPTION
## Description

## Problem
During release we need to update the `v{version}` tag.

## Solution
During release, parse the current tag, get the major version part and retag it with the current hash.

## Notes
Should fix the problem mentioned in https://github.com/Eun/http-server-action/pull/23

### Checklist
- [x] The title starts either with `feat:`, `fix:`, or `chore:`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes

