### PR TITLE
Improve Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Default:
 }
 ```
 ### `log`
-Create a log file with the given name (default is `off`) (*optional*)
+Create a log file with the given name (default is ``, which means no logging) (*optional*)
+
+### `logTime`
+Include the time of access in the log file (default is `true`) (*optional*)
 
 ## Example
 ```yaml
@@ -73,6 +76,7 @@ steps:
           "xml": "text/xml"
         }
       log: "log.txt"
+      logTime: "false"
   -
     run: |
       curl -vvvv http://localhost:8080/index.html

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,11 @@ inputs:
   log:
     description: 'Create a log file with given name'
     required: false
-    default: 'off'
+    default: ''
+  logTime:
+    description: 'Whether to include the time of access in the log file or not'
+    required: false
+    default: true
 runs:
   using: 'node16'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -33,7 +33,8 @@ let config = {
     indexFiles: null,
     allowedMethods: null,
     contentTypes: null,
-    log: null
+    log: null,
+    logTime: null
 };
 
 config.root = core.getInput('directory');
@@ -95,6 +96,13 @@ if (config.allowedMethods === null || config.allowedMethods.length == 0) {
 }
 
 config.log = core.getInput("log");
+
+config.logTime = core.getInput('logTime');
+if (config.logTime === null || config.logTime.length == 0) {
+    config.logTime = true;
+} else {
+    config.logTime = config.logTime === 'true';
+}
 
 const cp = require('child_process');
 const child = cp.fork(__filename, ['serve'], { detached: true, silent: true });

--- a/server.js
+++ b/server.js
@@ -26,7 +26,10 @@ function deploy(config, ready) {
         config.contentTypes = {};
     }
     if (config.log == undefined || config.log == null) {
-        config.log = "off";
+        config.log = "";
+    }
+	if (config.logTime == undefined || config.logTime == null) {
+        config.logTime = true;
     }
 
     const root = path.resolve(path.normalize(config.root));
@@ -40,27 +43,26 @@ function deploy(config, ready) {
     }
     
     let writeLine = (line) => {
-        if (config.log !== "off") {
-            let txtLogger = fs.createWriteStream(config.log, {
-                flags: 'a'
-            });
-            
-            txtLogger.write(`\n${line}`);
-        }
+		let txtLogger = fs.createWriteStream(config.log, {
+			flags: 'a'
+		});
+		
+		txtLogger.write(`\n${line}`);
     };
 
-    server.on('request', (request, response) => {
-        let now = formatTime.format(new Date());
-        let data = '';
+    server.on('request', (request, response) => {	
+        if (config.log !== "") {
+			let now = config.logTime ? `[${formatTime.format(new Date())}] ` : '';
+			let data = '';
 
-        request.on('data', (chunk) => {
-            data += chunk;
-        });
+			request.on('data', (chunk) => {
+				data += chunk;
+			});
 
-        request.on('end', () => {
-            writeLine(`[${now}] ${request.method} ${request.url} ${JSON.stringify(data)}`);
-        });
-
+			request.on('end', () => {
+				writeLine(`${now}${request.method} ${request.url} ${JSON.stringify(data)}`);
+			});
+        }
 
         if (config.noCache) {
             response.setHeader(


### PR DESCRIPTION
Hi,

I would suggest, that only fetch the request data, if log is not off. 
This way, if log is off, there will be no significant overhead.

Your initial plan with JSON-logs was good, because I could pick the data to compare.
But now, it is better to optional not log the timestamp. With this optional parameter, I can compare the log-file after running the test cases. If they are the same, the integration test is successful.

If you are approve this pull request, I would be very thankful, if you could release a new version, so I can use the new features.

Thanks for your time so far!

Viele Grüße, Simon