### PR TITLE
Fix: added synchronous mode for log writing

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ function deploy(config, ready) {
     let txtLogger = undefined;
     if (config.log !== "") {
         txtLogger = fs.createWriteStream(config.log, {
-            flags: 'a'
+            flags: 'as'
         });
     }
 


### PR DESCRIPTION
Regarding my concerns in #27, I have found a solution that is most neat: Adding an s.

When the option is set to "as", the following takes effect:
'as': Open file for appending in synchronous mode. The file is created if it does not exist.
https://nodejs.org/api/fs.html#file-system-flags

This is exactly what you would expect from a log file: The events are logged in the order in which they happened.

My tests run now without this race condition.