### PR TITLE
chore: `use actions/checkout@v3` in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Include the time of access in the log file (default is `true`) (*optional*)
 steps:
   -
     name: Checkout code
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
   -
     name: Serve Files
     uses: Eun/http-server-action@v1


### PR DESCRIPTION
## Description
Use `actions/checkout@v3` in sample GitHub action script in README.md

## Problem
The script uses an old version of `actions/checkout`.

## Solution
Use the latest version of version of `actions/checkout`.

### Checklist
- [x] The title starts either with `feat:`, `fix:`, or `chore:`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes

