### PR TITLE
chore: Update to use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,6 @@ inputs:
     required: false
     default: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
   post: 'post.js'


### PR DESCRIPTION
## Description

## Problem
Warning message for Node 16 deprecation.

## Solution
Update the action to use Node 20 per recommended action for Node 16 deprecation.
* Fixes: https://github.com/Eun/http-server-action/issues/36

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

### Checklist
- [x] The title starts either with `feat:`, `fix:`, or `chore:`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes

