### PR TITLE
chore: Update to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,6 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'
   post: 'post.js'


### PR DESCRIPTION
## Description

## Problem
Node.js 20 is deprecated and will stop workin
in June:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Solution
Update to Node.js 24

## Notes
The other open merge requests from dependabot are necessary, oo.

### Checklist
- [x] The title starts either with `feat:`, `fix:`, or `chore:`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes

